### PR TITLE
adding template functions for timestamps

### DIFF
--- a/docs/content/template/template-functions.md
+++ b/docs/content/template/template-functions.md
@@ -112,6 +112,20 @@ something
 </details>
 
 <details>
+<summary> **unixTS** -- Wrapper for [time.Now().Unix()](https://golang.org/pkg/time/#Unix). </summary>
+```
+{{ unixTS }}
+```
+</details>
+
+<details>
+<summary> **dateRFC3339** -- Wrapper for [time.Now().Format(time.RFC3339)](https://golang.org/pkg/time/). </summary>
+```
+{{ dateRFC3339 }}
+```
+</details>
+
+<details>
 <summary> **lookupIP** -- Wrapper for the [net.LookupIP](https://golang.org/pkg/net/#LookupIP) function. The wrapper returns the IP addresses in alphabetical order. </summary>
 ```
 {% for ip in lookupIP("kube-master") %}

--- a/pkg/template/template_funcs.go
+++ b/pkg/template/template_funcs.go
@@ -18,7 +18,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/HeavyHorst/remco/pkg/template/fileutil"
@@ -26,13 +28,15 @@ import (
 
 func newFuncMap() map[string]interface{} {
 	m := map[string]interface{}{
-		"getenv":     getenv,
-		"contains":   strings.Contains,
-		"replace":    strings.Replace,
-		"lookupIP":   lookupIP,
-		"lookupSRV":  lookupSRV,
-		"fileExists": fileutil.IsFileExist,
-		"printf":     fmt.Sprintf,
+		"getenv":      getenv,
+		"contains":    strings.Contains,
+		"replace":     strings.Replace,
+		"lookupIP":    lookupIP,
+		"lookupSRV":   lookupSRV,
+		"fileExists":  fileutil.IsFileExist,
+		"printf":      fmt.Sprintf,
+		"unixTS":      unixTimestampNow,
+		"dateRFC3339": dateRFC3339Now,
 	}
 
 	return m
@@ -86,4 +90,12 @@ func lookupSRV(service, proto, name string) ([]*net.SRV, error) {
 		return str1 < str2
 	})
 	return addrs, nil
+}
+
+func unixTimestampNow() string {
+	return strconv.FormatInt(time.Now().Unix(), 10)
+}
+
+func dateRFC3339Now() string {
+	return time.Now().Format(time.RFC3339)
 }


### PR DESCRIPTION
Hello,

I think timestamp functions could be useful. 
It can be use to have an ever increasing ID (unix timestamp) or mark the data of last generation (RFC3339).

Not sure if it was possible using another way in Pongo2, but I've not found it, so I've added the following functions: 

* unixTS: a template function to get the current date as a unix timestamp
* dateRFC3339: a template function to get the current date in RFC3339 format

I've also added the documentation for it.
Not sure how to create unit tests for these as there are relatively simple and there output is by definition changing all the time ^^.

I'm also unsure about the "esthetic" of function names.