### PR TITLE
Add onetime cli param

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ $ mv remco_linux /usr/local/bin/remco
 
 Now you can run the remco command!
 
+## Execution
+
+run remco from local dir, configuration is read as default from `/etc/remco/config`
+
+Command line params:
+
+| parameter | description |
+| --- | --- |
+| -config <file> | path to the configuration file |
+| -onetime | flag to one run templating once, overriding "Onetime" flag for all backend resources |
+| -version | print version and exit |
+
 ## Contributing
 
 See [Contributing](https://github.com/HeavyHorst/remco/blob/master/CONTRIBUTING) for details on submitting patches.

--- a/pkg/backends/consul.go
+++ b/pkg/backends/consul.go
@@ -75,3 +75,8 @@ func (c *ConsulConfig) Connect() (template.Backend, error) {
 
 	return c.Backend, nil
 }
+
+// return Backend config to allow modification before connect() for onetime param or similar
+func (c *ConsulConfig) GetBackend() *template.Backend {
+	return &c.Backend
+}

--- a/pkg/backends/env.go
+++ b/pkg/backends/env.go
@@ -34,3 +34,8 @@ func (c *EnvConfig) Connect() (template.Backend, error) {
 	c.Backend.ReadWatcher = client
 	return c.Backend, nil
 }
+
+// return Backend config to allow modification before connect() for onetime param or similar
+func (c *EnvConfig) GetBackend() *template.Backend {
+	return &c.Backend
+}

--- a/pkg/backends/etcd.go
+++ b/pkg/backends/etcd.go
@@ -111,3 +111,8 @@ func (c *EtcdConfig) Connect() (template.Backend, error) {
 	c.Backend.ReadWatcher = client
 	return c.Backend, nil
 }
+
+// return Backend config to allow modification before connect() for onetime param or similar
+func (c *EtcdConfig) GetBackend() *template.Backend {
+	return &c.Backend
+}

--- a/pkg/backends/file.go
+++ b/pkg/backends/file.go
@@ -46,3 +46,8 @@ func (c *FileConfig) Connect() (template.Backend, error) {
 	c.Backend.ReadWatcher = client
 	return c.Backend, nil
 }
+
+// return Backend config to allow modification before connect() for onetime param or similar
+func (c *FileConfig) GetBackend() *template.Backend {
+	return &c.Backend
+}

--- a/pkg/backends/mock.go
+++ b/pkg/backends/mock.go
@@ -35,3 +35,8 @@ func (c *MockConfig) Connect() (template.Backend, error) {
 
 	return c.Backend, nil
 }
+
+// return Backend config to allow modification before connect() for onetime param or similar
+func (c *MockConfig) GetBackend() *template.Backend {
+	return &c.Backend
+}

--- a/pkg/backends/plugin/plugin.go
+++ b/pkg/backends/plugin/plugin.go
@@ -55,6 +55,11 @@ func (p *Plugin) Connect() (template.Backend, error) {
 	return p.Backend, nil
 }
 
+// return Backend config to allow modification before connect() for onetime param or similar
+func (p *Plugin) GetBackend() *template.Backend {
+	return &p.Backend
+}
+
 // initPlugin sends the config map to the plugin
 // the plugin can then run some initialization tasks
 func (p *plug) initPlugin(config map[string]interface{}) error {

--- a/pkg/backends/redis.go
+++ b/pkg/backends/redis.go
@@ -71,3 +71,8 @@ func (c *RedisConfig) Connect() (template.Backend, error) {
 
 	return c.Backend, nil
 }
+
+// return Backend config to allow modification before connect() for onetime param or similar
+func (c *RedisConfig) GetBackend() *template.Backend {
+	return &c.Backend
+}

--- a/pkg/backends/vault.go
+++ b/pkg/backends/vault.go
@@ -100,3 +100,8 @@ func (c *VaultConfig) Connect() (template.Backend, error) {
 
 	return c.Backend, nil
 }
+
+// return Backend config to allow modification before connect() for onetime param or similar
+func (c *VaultConfig) GetBackend() *template.Backend {
+	return &c.Backend
+}

--- a/pkg/backends/zookeeper.go
+++ b/pkg/backends/zookeeper.go
@@ -56,3 +56,8 @@ func (c *ZookeeperConfig) Connect() (template.Backend, error) {
 	c.Backend.ReadWatcher = client
 	return c.Backend, nil
 }
+
+// return Backend config to allow modification before connect() for onetime param or similar
+func (c *ZookeeperConfig) GetBackend() *template.Backend {
+	return &c.Backend
+}

--- a/pkg/template/backend.go
+++ b/pkg/template/backend.go
@@ -27,6 +27,7 @@ import (
 // Connect should also set the name and the StoreClient of the Backend. The other values of Backend will be loaded from the configuration file.
 type BackendConnector interface {
 	Connect() (Backend, error)
+	GetBackend() *Backend
 }
 
 // Backend is the representation of a template backend like etcd or consul


### PR DESCRIPTION
Patch to add new `-onetime` command line parameter to run the templateing process only once and exit afterwards.
This command line param overwrite the "Onetime" flag from all backend resources configured.

Issue related: #74

I have not found a place where to add this to the current documentation below the `docs/` directory. Only mentioned flag inside the readme file instead.

Current patch is working as long as templates can be rendered - every is created and "remco" exits.

And another problem i found - current implementation does not respect the "onetime" config flag in case of an error (e.g. Network/Host unreachable, password wrong or templates not found etc.). Running into such a problem "remco" goes into an endless loop and retries again and again making the "Onetime" config param kinda useless.

I think remco should not go into a loop retrying when "ontime" flag is set for a specific config. What do you think?