### PR TITLE
do not retry resource templating on error for "onetime" resources

### DIFF
--- a/cmd/remco/main.go
+++ b/cmd/remco/main.go
@@ -15,6 +15,7 @@ import (
 	"os/signal"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/HeavyHorst/remco/pkg/log"
@@ -36,7 +37,7 @@ func init() {
 	flag.BoolVar(&onetime, "onetime", false, "run templating process once and exit")
 }
 
-func run() int {
+func run() int32 {
 	// catch all signals
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan)
@@ -100,7 +101,7 @@ func run() int {
 		case err := <-errorReapChan:
 			log.Error(fmt.Sprintf("Error reaping child process %v", err))
 		case <-done:
-			return run.resourcesWithError
+			return atomic.LoadInt32(&run.resourcesWithError)
 		}
 	}
 }
@@ -117,5 +118,5 @@ func main() {
 	if rc > 125 {
 		rc = 125
 	}
-	os.Exit(rc)
+	os.Exit(int(rc))
 }

--- a/pkg/template/backend.go
+++ b/pkg/template/backend.go
@@ -81,9 +81,11 @@ func connectAllBackends(ctx context.Context, bc []BackendConnector) ([]Backend, 
 						"backend": b.Name,
 					}).Error(errors.Wrap(err, "connect failed"))
 
-					//try again after 2 seconds
-					time.Sleep(2 * time.Second)
-					continue retryloop
+					//try again after 2 seconds to watch
+					if config.GetBackend().Onetime != true {
+						time.Sleep(2 * time.Second)
+						continue retryloop
+					}
 				}
 				break retryloop
 			}


### PR DESCRIPTION
this patch exits after one failed attempt when a resource has the "Onetime" flag set.
The resource is not retried for connection errors (no route to host or wrong password) and templating errors (template file missing, wrong key referenced,...)

As i do not speak this language i do not know if this is the way to "go" to return error values for the process on execution failures. From a users point of view it is really helpful to have an exit code != 0 on failures but this seems a bit more complicated with go and defered and channels and stuff...

Open for any changes here...

remark: the `make test` is failing with an yaml pongo2 error. This test fails without this PR too.
