### PR TITLE
add new method "SortedSet()" to template set object

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ for remco, referred to as The Remco Authors.
 
 Rene Kaufmann <kaufmann.r@gmail.com>
 Rashit Azizbaev <syndicut@gmail.com>
+Stefan Seide <account-github@seide.st>

--- a/docs/content/template/template-functions.md
+++ b/docs/content/template/template-functions.md
@@ -166,16 +166,21 @@ something
 
 ```
 {% set map = createMap() %}
-{{  map.Set("Moin", "Hallo2") }}
-{{  map.Set("Test", 105) }}
+{{ map.Set("Moin", "Hallo2") }}
+{{ map.Set("Test", 105) }}
 {{ map | toYAML }}
 
 {% set map2 = createMap() %}
-{{  map2.Set("Moin", "Hallo") }}
-{{  map2.Set("Test", 300) }}
-{{  map2.Set("anotherMap", map) }}
+{{ map2.Set("Moin", "Hallo") }}
+{{ map2.Set("Test", 300) }}
+{{ map2.Set("anotherMap", map) }}
 {{ map2 | toYAML }}
 ```
+
+The hashmap supports the following methods:
+* `m.Set("key", value)` adds a new value of arbitrary type referenced by "key" to the map
+* `m.Get("key")` get the value for the given "key"
+* `m.Remove("key")` removes the key and value from the map
 </details>
 
 <details>
@@ -183,10 +188,38 @@ something
 
 ```
 {% set s = createSet() %}
-{{  s.Append("Moin") }}
-{{  s.Append("Moin") }}
-{{  s.Append("Hallo") }}
-{{  s.Append(1) }}
+{{ s.Append("Moin") }}
+{{ s.Append("Moin") }}
+{{ s.Append("Hallo") }}
+{{ s.Append(1) }}
+{{ s.Remove("Hallo") }}
 {{ s | toYAML }}
 ```
+The set created supports the following methods:
+* `s.Append("string")` adds a new string to the set. Attention - the set is not
+  sorted or the order of appended elements guaranteed.
+* `s.Remove("string")` removes the given element from the set.
+* `s.Contains("string")` check if the given string is part of the set, returns
+  true or false otherwise
+* `s.SortedSet()` return a new list where all elements are sorted in increasing
+  order. This method should be used inside the template with a for-in loop to generate
+ a stable output file not changing order of elements on every run. 
+
+```
+{% set s = createSet() %}
+{% s.Append("Moin") %}
+{% s.Append("Hi") %}
+{% s.Append("Hallo") %}
+
+{% for greeting in s %}
+{{ geeting }}
+{% endfor %}
+
+{% for greeting in s.SortedSet() %}
+{{ geeting }}
+{% endfor %}
+```
+
+The output of the first loop is not defined, it can be in every order (like `Moin Hallo Hi` or `Hi Hallo Moin` and so on)
+The second loop returns every time `Hallo Hi Moin` (items sorted as string in increasing order)
 </details>

--- a/pkg/template/template_funcs.go
+++ b/pkg/template/template_funcs.go
@@ -48,28 +48,20 @@ func (s interfaceSet) Contains(value interface{}) bool {
 }
 
 func (s interfaceSet) SortedSet() []string {
-	var out []string
-	for k := range s {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
-}
-
-func (s interfaceSet) toSet() []string {
 	var i []string
 	for k := range s {
 		i = append(i, k)
 	}
+	sort.Strings(i)
 	return i
 }
 
 func (s interfaceSet) MarshalYAML() (interface{}, error) {
-	return s.toSet(), nil
+	return s.SortedSet(), nil
 }
 
 func (s interfaceSet) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.toSet())
+	return json.Marshal(s.SortedSet())
 }
 
 type templateMap map[string]interface{}

--- a/pkg/template/template_funcs.go
+++ b/pkg/template/template_funcs.go
@@ -47,12 +47,20 @@ func (s interfaceSet) Contains(value interface{}) bool {
 	return c
 }
 
+func (s interfaceSet) SortedSet() []string {
+	var out []string
+	for k := range s {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func (s interfaceSet) toSet() []string {
 	var i []string
 	for k := range s {
 		i = append(i, k)
 	}
-
 	return i
 }
 

--- a/pkg/template/template_funcs_test.go
+++ b/pkg/template/template_funcs_test.go
@@ -116,6 +116,11 @@ func (s *FunctionTestSuite) TestInterfaceSet(t *C) {
 	t.Check(len(set), Equals, 3)
 	t.Check(set.Contains("Hallo"), Equals, false)
 	t.Check(set.Contains(false), Equals, true)
+
+	t.Check(len(set.SortedSet()), Equals, 3)
+	t.Check(set.SortedSet()[0], Equals, "1")
+	t.Check(set.SortedSet()[1], Equals, "false")
+	t.Check(set.SortedSet()[2], Equals, "true")
 }
 
 func (s *FunctionTestSuite) TestTemplateMap(t *C) {


### PR DESCRIPTION
Your implementation adds the very helpful `createMap()` and `createSet()` methods.
As booth objects are backed by a hashmap the order of the items is not defined. Therefore using a set 
to collect all items and write them into the file afterwards produces different files on every run - the checksum
differs every time and the file gets overwritten on every run. This comes a bit of a surprise as "Append" suggests an order.

To get a stable output the new function `SortedSet()` for the Set interface is addded.

Example (added to documentation too):
```
{% set s = createSet() %}
{% s.Append("Moin") %}
{% s.Append("Hi") %}
{% s.Append("Hallo") %}

{% for greeting in s %}
{{ geeting }}
{% endfor %}

{% for greeting in s.SortedSet() %}
{{ geeting }}
{% endfor %}
```
The first run (as possible without this PR only) creates a different file on every run overwriting the old one.
With this new method it is possible to generated predictable output that does not differ between multpile runs of remco.