### PR TITLE
Add an etcd backend option to choose linearizable reads

### DIFF
--- a/pkg/backends/etcd.go
+++ b/pkg/backends/etcd.go
@@ -44,6 +44,10 @@ type EtcdConfig struct {
 	// The password for the basic_auth authentication.
 	Password string
 
+	// Whether to use serializable reads rather than linearizable ones, see
+	// <https://etcd.io/docs/v3.3/learning/api_guarantees/#linearizability>.
+	UseSerializableReads bool `toml:"use_serializable_reads"`
+
 	// The etcd api-level to use (2 or 3).
 	//
 	// The default is 2.
@@ -101,6 +105,7 @@ func (c *EtcdConfig) Connect() (template.Backend, error) {
 			ClientKey:    c.ClientKey,
 			ClientCaKeys: c.ClientCaKeys,
 		}),
+		etcd.WithSerializableReads(c.UseSerializableReads),
 		etcd.WithVersion(c.Version))
 
 	if err != nil {


### PR DESCRIPTION
Remco uses easyKV, which uses [linearizable reads](https://etcd.io/docs/v3.3/learning/api_guarantees/#linearizability) with both etcd v2 and etcd v3. This comes with a delay cost.

This PR adds an option to choose linearizable reads. It depends on an [easyKV PR](https://github.com/HeavyHorst/easykv/pull/14), so it will first require tagging a new easyKV version and updating go.mod to use it.