### PR TITLE
Stringify all input parameter before calling GoJa runtime

### DIFF
--- a/pkg/template/template_filters.go
+++ b/pkg/template/template_filters.go
@@ -77,8 +77,8 @@ func pongoJSFilter(name string, js string) func(in *pongo2.Value, param *pongo2.
 	return func(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
 		vm := goja.New()
 
-		vm.Set("In", in.Interface())
-		vm.Set("Param", param.Interface())
+		vm.Set("In", in.String())
+		vm.Set("Param", param.String())
 
 		v, err := vm.RunString(js)
 		if err != nil {


### PR DESCRIPTION
current implementation using `Interface()` does not work in some cases, depending on how the string is created within the template. One example is a string created via `index` Filter - it cannot be worked on in Javascript filter applied later onto this "String".

Example not working with old version - Javascript filters fail on these data:

1. Simple custom Javascript Filter `checkJS.js`:
  ```js
  typeof In === 'string';
  ```
2. Remco Template to process:
  ```django
  {%- set pathWL = "/blah=1.2.3.4" %}
  {%- set wl = pathWL | split:"=" %}
  pathWL: "{{pathWL}}"
  wl: {{wl | toJSON}}

  {% set pathIndex = wl | index:"0" %}
  pathIndex in template: "{{pathIndex}}"
  pathIndex is String in Javascript: {{pathIndex | checkJS}}

  {% set pathFirst = wl | first %}
  pathFirst in template: "{{pathFirst}}"
  pathFirst is String in Javascript: {{pathFirst | checkJS}}

  {% set pathLast = wl | last %}
  pathFirst in template: "{{pathLast}}"
  pathFirst is String in Javascript: {{pathLast | checkJS}}
  ```

Running this template gives the following outout:
```
pathWL: "/blah=1.2.3.4"
wl: ["/blah","1.2.3.4"]

pathIndex in template: "/blah"
pathIndex is String in Javascript: False

pathFirst in template: "/blah"
pathFirst is String in Javascript: True

pathFirst in template: "1.2.3.4"
pathFirst is String in Javascript: True
```

As long as one uses template language only there is no problem with this `split`/`index` calls, they are handled as expected.
Now giving the result of the `index` filter into a Javascript filter it fails because it is no string. (what is it? do not know go that much...). Using `first` or `last` filter instead these values are strings and the Javascript filter work as expected.

The solution is to explicit convert the GoJa parameters to a String before calling the GoJa runtime.
The output of the same filter / template with this fix is the following, now the JS filter work as expected.

```
pathWL: "/blah=1.2.3.4"
wl: ["/blah","1.2.3.4"]

pathIndex in template: "/blah"
pathIndex is String in Javascript: True

pathFirst in template: "/blah"
pathFirst is String in Javascript: True

pathFirst in template: "1.2.3.4"
pathFirst is String in Javascript: True
```
