### PR TITLE
re #111 - Add base64decode

### DIFF
--- a/pkg/template/template_filters.go
+++ b/pkg/template/template_filters.go
@@ -43,6 +43,7 @@ func init() {
 	pongo2.RegisterFilter("dir", filterDir)
 	pongo2.RegisterFilter("base", filterBase)
 	pongo2.RegisterFilter("base64", filterBase64)
+	pongo2.RegisterFilter("base64decode", filterBase64Decode)
 	pongo2.RegisterFilter("index", filterIndex)
 	pongo2.RegisterFilter("mapValue", filterMapValue)
 }
@@ -104,6 +105,20 @@ func filterBase64(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2
 	}
 	sEnc := base64.StdEncoding.EncodeToString([]byte(in.String()))
 	return pongo2.AsValue(sEnc), nil
+}
+
+func filterBase64Decode(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
+	if !in.IsString() {
+		return in, nil
+	}
+	val, err := base64.StdEncoding.DecodeString(in.String())
+	if err != nil {
+		return nil, &pongo2.Error{
+			Sender:    "filter:filterBase64Decode",
+			OrigError: err,
+		}
+	}
+	return pongo2.AsValue(string(val)), nil
 }
 
 func filterBase(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {

--- a/pkg/template/template_filters_test.go
+++ b/pkg/template/template_filters_test.go
@@ -33,6 +33,16 @@ func (s *FilterSuite) TestFilterBase64(t *C) {
 	t.Check(res.String(), Equals, "Zm9v")
 }
 
+func (s *FilterSuite) TestFilterBase64Decode(t *C) {
+	in := pongo2.AsValue("Zm9v")
+	res, err := filterBase64Decode(in, nil)
+	if err != nil {
+		t.Error(err.OrigError)
+	}
+
+	t.Check(res.String(), Equals, "foo")
+}
+
 func (s *FilterSuite) TestFilterBase(t *C) {
 	in := pongo2.AsValue("/etc/foo/bar")
 	res, err := filterBase(in, nil)


### PR DESCRIPTION
Add template filter `base64decode` to convert a value from base64 into a plain string.

I'm open to other suggestions regarding the name. It may also be desirable to expose the existing `base64` filter as `base64encode` while retaining the original name for backwards compatibility.