### PR TITLE
feat(security): fix CVE-2025-22872 / CVE-2025-47906

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/HeavyHorst/remco
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/BurntSushi/toml v1.2.1
@@ -85,7 +85,7 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.22.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.11.0 // indirect


### PR DESCRIPTION
Security Patch:

Update go up to 1.24.6
Update net up to 0.38

Tested with Trivy :
```
trivy rootfs ./bin/remco
2025-09-19T11:42:29+02:00       INFO    [vuln] Vulnerability scanning is enabled
2025-09-19T11:42:29+02:00       INFO    [secret] Secret scanning is enabled
2025-09-19T11:42:29+02:00       INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-09-19T11:42:29+02:00       INFO    [secret] Please see also https://trivy.dev/v0.65/docs/scanner/secret#recommendation for faster secret detection
2025-09-19T11:42:29+02:00       INFO    Number of language-specific files       num=1
2025-09-19T11:42:29+02:00       INFO    [gobinary] Detecting vulnerabilities...

Report Summary

┌────────┬──────────┬─────────────────┬─────────┐
│ Target │   Type   │ Vulnerabilities │ Secrets │
├────────┼──────────┼─────────────────┼─────────┤
│ remco  │ gobinary │        0        │    -    │
└────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```

Didn’t see guidelines for PR so let me know if I need to adapt.