### PR TITLE
fix: return error on tokenless exec_command instead of panicking

### DIFF
--- a/pkg/template/executor.go
+++ b/pkg/template/executor.go
@@ -134,6 +134,10 @@ func (e *Executor) SpawnChild() error {
 			return err
 		}
 
+		if len(args) == 0 {
+			return fmt.Errorf("exec_command %q parsed to no tokens", e.execCommand)
+		}
+
 		c, err = child.New(&child.NewInput{
 			Stdin:        os.Stdin,
 			Stdout:       os.Stdout,

--- a/pkg/template/executor_test.go
+++ b/pkg/template/executor_test.go
@@ -261,3 +261,15 @@ func TestExecutorLogging(t *testing.T) {
 		t.Errorf("Log output did not match out expectations. Was '%s'", s)
 	}
 }
+
+
+func TestSpawnChildEmptyCommand(t *testing.T) {
+	for _, command := range []string{"   ", "	", " 	 "} {
+		logger := hclog.New(&hclog.LoggerOptions{Output: ioutil.Discard})
+		exec := NewExecutor(command, "", "", 0, 0, logger)
+		err := exec.SpawnChild()
+		if err == nil {
+			t.Errorf("SpawnChild with command %q should return an error, got nil", command)
+		}
+	}
+}


### PR DESCRIPTION
SpawnChild parsed exec_command with shellwords and then indexed args[0]/args[1:] without checking the result. A whitespace-only command parses to zero tokens but returns no error, so the index panicked with 'slice bounds out of range'. The fix checks for an empty token list and returns a clear error instead of crashing the reconciler.